### PR TITLE
fix: reverted to two stepepd login

### DIFF
--- a/ui/src/routes/_marketplace/checkout.tsx
+++ b/ui/src/routes/_marketplace/checkout.tsx
@@ -1,10 +1,11 @@
 import { useCart } from '@/hooks/use-cart';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { ChevronLeft, CreditCard } from 'lucide-react';
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { apiClient } from '@/utils/orpc';
 import { toast } from 'sonner';
+import { authClient } from '@/lib/auth-client';
 
 export const Route = createFileRoute("/_marketplace/checkout")({
   component: CheckoutPage,
@@ -13,6 +14,7 @@ export const Route = createFileRoute("/_marketplace/checkout")({
 function CheckoutPage() {
   const { cartItems, subtotal } = useCart();
   const [discountCode, setDiscountCode] = useState("");
+  const navigate = useNavigate();
 
   const tax = subtotal * 0.08;
   const total = subtotal + tax;
@@ -47,7 +49,19 @@ function CheckoutPage() {
     },
   });
 
-  const handlePayWithCard = () => {
+  const handlePayWithCard = async () => {
+    // Check if user is authenticated before proceeding with checkout
+    const { data: session } = await authClient.getSession();
+    if (!session?.user) {
+      navigate({
+        to: "/login",
+        search: {
+          redirect: "/checkout",
+        },
+      });
+      return;
+    }
+
     checkoutMutation.mutate();
   };
 

--- a/ui/src/routes/_marketplace/login.tsx
+++ b/ui/src/routes/_marketplace/login.tsx
@@ -188,7 +188,7 @@ function LoginPage() {
                 <img
                   src={nearLogo}
                   alt="NEAR"
-                  className="w-full h-full object-contain"
+                  className="w-full h-full object-contain invert dark:invert-0"
                 />
               </div>
               <span className="text-sm">


### PR DESCRIPTION
## Fix: Light theme NEAR logo and checkout authentication

### Changes
- **Login page**: Added `invert dark:invert-0` to the NEAR logo so it displays correctly in light mode.
- **Checkout page**: Added authentication check before checkout API call. Unauthenticated users are redirected to login with a redirect parameter to return to checkout after signing in.

### Technical details
- Login page: Updated logo image className to invert on light mode
- Checkout page: Added `authClient.getSession()` check in `handlePayWithCard` with redirect to `/login?redirect=/checkout`

No breaking changes. Maintains existing two-step NEAR login flow.