### PR TITLE
fix: enable historyApiFallback for SPA direct links

### DIFF
--- a/host/rsbuild.config.ts
+++ b/host/rsbuild.config.ts
@@ -105,6 +105,7 @@ export default defineConfig({
       '/api': 'http://localhost:3000',
       '/__runtime-config': 'http://localhost:3000',
     },
+    historyApiFallback: true,
   },
   tools: {
     rspack: {


### PR DESCRIPTION
  ## Summary
  - Added `historyApiFallback: true` to rsbuild dev server config
  - Direct links to product pages (e.g., `/products/printful-product-406664962`) now load correctly

  ## Problem
  When navigating directly to a product URL or refreshing on a product page, the page would show blank because the dev server was trying to find that file path instead of serving `index.html` for client-side routing.

  ## Solution
  Enable `historyApiFallback` in `host/rsbuild.config.ts` so all non-API routes fall back to `index.html`, allowing TanStack Router to handle the routing client-side.

  Fixes #19
