### PR TITLE
Fixed scrollPositioning while page changing

### DIFF
--- a/host/src/main.tsx
+++ b/host/src/main.tsx
@@ -68,7 +68,8 @@ export const Main: FC = () => {
 
   return (
     <div style={containerStyle}>
-      <div style={contentStyle}>
+      {/* ID added for TanStack Router scroll restoration - this is the main scrollable container */}
+      <div id="main-scroll-container" style={contentStyle}>
         <ErrorBoundary
           onError={(error) => {
             console.error('[Host] Failed to load remote app:', error.message);

--- a/ui/src/bootstrap.tsx
+++ b/ui/src/bootstrap.tsx
@@ -17,7 +17,14 @@ const router = createRouter({
     ...TanStackQueryProviderContext,
   },
   defaultPreload: 'intent',
+  // Enable scroll restoration for back/forward navigation
   scrollRestoration: true,
+  // Use 'instant' to avoid jarring smooth scroll when restoring positions
+  scrollRestorationBehavior: 'instant',
+  // Target the host's scroll container for scroll-to-top on new navigations
+  // The host wraps the UI in a div#main-scroll-container with overflow: auto
+  // Also include 'window' as fallback for standalone mode
+  scrollToTopSelectors: ['#main-scroll-container', 'window'],
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
 });

--- a/ui/src/components/marketplace/product-card.tsx
+++ b/ui/src/components/marketplace/product-card.tsx
@@ -166,6 +166,7 @@ function VerticalProductLayout({
           to="/products/$productId"
           params={{ productId: product.id }}
           className="block w-full h-full"
+          resetScroll={true}
         >
           {displayImage ? (
             <img
@@ -213,6 +214,7 @@ function VerticalProductLayout({
             to="/products/$productId"
             params={{ productId: product.id }}
             className="block"
+            resetScroll={true}
           >
             <h3
               className={cn(
@@ -274,6 +276,7 @@ function HorizontalProductLayout({
           to="/products/$productId"
           params={{ productId: product.id }}
           className="block w-full h-full"
+          resetScroll={true}
         >
           {displayImage ? (
             <img
@@ -297,6 +300,7 @@ function HorizontalProductLayout({
               to="/products/$productId"
               params={{ productId: product.id }}
               className="block"
+              resetScroll={true}
             >
               <h3 className="font-medium text-foreground leading-tight transition-colors hover:text-primary text-base">
                 {product.title}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -12,7 +12,14 @@ const router = createRouter({
     ...TanStackQueryProviderContext,
   },
   defaultPreload: 'intent',
+  // Enable scroll restoration for back/forward navigation
   scrollRestoration: true,
+  // Use 'instant' to avoid jarring smooth scroll when restoring positions
+  scrollRestorationBehavior: 'instant',
+  // Target the host's scroll container for scroll-to-top on new navigations
+  // The host wraps the UI in a div#main-scroll-container with overflow: auto
+  // Also include 'window' as fallback for standalone mode
+  scrollToTopSelectors: ['#main-scroll-container', 'window'],
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
 });


### PR DESCRIPTION
issue no: 67

Solution: The host app uses a custom scroll container (`overflow: auto`) instead of `window`. Added id="main-scroll-container" to the host's scroll div, then configured TanStack Router with scrollToTopSelectors: ['#main-scroll-container', 'window'] and added resetScroll={true} to product Links.

Video: https://res.cloudinary.com/dnawowsqi/video/upload/v1767115124/nearissue1_daxkjw.mp4

Time: 3hrs