### PR TITLE
added useCanGoBack hook for going back

### DIFF
--- a/ui/src/routes/_marketplace/products/$productId.tsx
+++ b/ui/src/routes/_marketplace/products/$productId.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/product-utils";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/utils/orpc";
-import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { createFileRoute, Link, useRouter, useCanGoBack } from "@tanstack/react-router";
 import {
   AlertCircle,
   ArrowLeft,
@@ -93,6 +93,8 @@ export const Route = createFileRoute("/_marketplace/products/$productId")({
 });
 
 function ProductDetailPage() {
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
   const { addToCart } = useCart();
   const { favoriteIds, toggleFavorite } = useFavorites();
 
@@ -224,13 +226,19 @@ function ProductDetailPage() {
 
       <div className="border-b border-border">
         <div className="max-w-[1408px] mx-auto px-4 md:px-8 lg:px-16 py-4">
-          <Link
-            to="/"
-            className="flex items-center gap-3 hover:opacity-70 transition-opacity"
+          <button
+            onClick={() => {
+              if (canGoBack) {
+                router.history.back();
+              } else {
+                router.navigate({ to: "/" });
+              }
+            }}
+            className="flex items-center gap-3 hover:opacity-70 transition-opacity cursor-pointer"
           >
             <ArrowLeft className="size-4" />
             <span className="tracking-[-0.48px]">Back to Shop</span>
-          </Link>
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Problem: 
When users navigated from the homepage → `/products` → product detail page, clicking the "Back to Shop" button would always redirect to the homepage (`/`) instead of returning to the `/products` page where they came from.

Fixed the "Back to Shop" button on the product detail page to navigate to the previous page in browser history instead of always redirecting to the homepage. This provides a better user experience when navigating from the `/products` page to a product detail page.

Implemented TanStack Router's `useCanGoBack` hook and `router.history.back()` method to properly handle browser history.