### PR TITLE
Fix Printful orders created without designs and draft confirmation failures

### DIFF
--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -484,6 +484,36 @@ export const contract = oc.router({
       }),
     ),
 
+  retryPendingConfirmations: oc
+    .route({
+      method: "POST",
+      path: "/cron/retry-confirmations",
+      summary: "Retry pending fulfillment confirmations",
+      description:
+        "Retries Printful draft order confirmations for orders stuck in paid_pending_fulfillment. Intended to be called by a cron job every 5-10 minutes.",
+      tags: ["Jobs"],
+    })
+    .input(
+      z.object({
+        olderThanMinutes: z.number().int().positive().default(5).optional(),
+      }),
+    )
+    .output(
+      z.object({
+        totalProcessed: z.number(),
+        confirmed: z.number(),
+        stillPending: z.number(),
+        failed: z.number(),
+        errors: z.array(
+          z.object({
+            orderId: z.string(),
+            provider: z.string(),
+            error: z.string(),
+          }),
+        ),
+      }),
+    ),
+
   getNearPrice: oc
     .route({
       method: "GET",

--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -1050,6 +1050,7 @@ export const contract = oc.router({
       name: z.string().optional(),
       description: z.string().nullable().optional(),
       price: z.number().positive().optional(),
+      priceLocked: z.boolean().optional(),
       images: z.array(ProductImageSchema).optional(),
       thumbnailImage: z.string().nullable().optional(),
     }))

--- a/api/src/db/migrations/0011_wakeful_the_enforcers.sql
+++ b/api/src/db/migrations/0011_wakeful_the_enforcers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "products" ADD COLUMN "price_locked" boolean DEFAULT false NOT NULL;

--- a/api/src/db/migrations/meta/0011_snapshot.json
+++ b/api/src/db/migrations/meta/0011_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "4a7901c2-c341-43d5-bcde-7b39deabb2c8",
-  "prevId": "4d60edfd-2619-48b3-a79c-71f84dc39ade",
+  "id": "8dcb3370-5d4f-4dac-8a69-e49333e140ae",
+  "prevId": "4a7901c2-c341-43d5-bcde-7b39deabb2c8",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1394,6 +1394,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": true
+        },
+        "price_locked": {
+          "name": "price_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
         },
         "created_at": {
           "name": "created_at",

--- a/api/src/db/migrations/meta/_journal.json
+++ b/api/src/db/migrations/meta/_journal.json
@@ -65,19 +65,26 @@
       "tag": "0008_old_vanisher",
       "breakpoints": true
     },
-{
-  "idx": 9,
-  "version": "7",
-  "when": 1776528135295,
-  "tag": "0009_funny_hobgoblin",
-  "breakpoints": true
-},
-{
-  "idx": 10,
-  "version": "7",
-  "when": 1776600000000,
-  "tag": "0010_migrate_fulfillment_config",
-  "breakpoints": true
-}
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776528135295,
+      "tag": "0009_funny_hobgoblin",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776600000000,
+      "tag": "0010_migrate_fulfillment_config",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777919710374,
+      "tag": "0011_wakeful_the_enforcers",
+      "breakpoints": true
+    }
   ]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -89,6 +89,7 @@ export const products = pgTable(
       mode: "date",
     }),
     listed: boolean("listed").notNull().default(true),
+    priceLocked: boolean("price_locked").notNull().default(false),
 
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" })
       .notNull()

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1286,8 +1286,33 @@ export default createPlugin({
               });
             }
 
-            const { eventType, externalId, data } =
+            const { eventType, externalId, catalogProductId, data } =
               parsePrintfulWebhook(rawBody);
+
+            if (eventType === 'catalog_price_changed' && catalogProductId) {
+              console.log(
+                `[Printful Webhook] Catalog price changed for product: ${catalogProductId}`,
+              );
+              try {
+                const { PrintfulService: PFSvc } = await import('./services/fulfillment/printful/service');
+                const pfService = new PFSvc(
+                  secrets.PRINTFUL_API_KEY!,
+                  secrets.PRINTFUL_STORE_ID!,
+                );
+                const productStore = await managedRuntime.runPromise(
+                  Effect.gen(function* () {
+                    return yield* ProductStore;
+                  }),
+                );
+                await pfService.handleCatalogPriceChange(String(catalogProductId), productStore);
+              } catch (error) {
+                console.warn(
+                  `[Printful Webhook] Failed to handle catalog_price_changed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+              }
+              return { received: true };
+            }
+
             if (!externalId) {
               return { received: true };
             }
@@ -2168,6 +2193,7 @@ export default createPlugin({
                 name: input.name,
                 description: input.description,
                 price: input.price,
+                priceLocked: input.priceLocked,
                 images: input.images,
                 thumbnailImage: input.thumbnailImage,
               });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,7 @@ import { ORPCError } from 'every-plugin/orpc';
 import { z } from 'every-plugin/zod';
 import { contract } from './contract';
 import { cleanupAbandonedDrafts } from './jobs/cleanup-drafts';
+import { retryPendingConfirmations } from './jobs/retry-confirmations';
 import { createMarketplaceRuntime } from './runtime';
 import { ReturnAddressSchema, type ConfigureWebhookOutput, type OrderStatus, type PrintfulWebhookEventType, type ProductMetadata, type ProviderWebhookEventType, type TrackingInfo } from './schema';
 import { CheckoutService, CheckoutServiceLive } from './services/checkout';
@@ -1310,7 +1311,7 @@ export default createPlugin({
               return { received: true };
             }
 
-            const { newStatus, newTracking } = computePrintfulUpdate({
+            const { newStatus, newTracking, shouldRetryConfirmation } = computePrintfulUpdate({
               eventType,
               data,
               currentStatus: order.status,
@@ -1330,6 +1331,49 @@ export default createPlugin({
                   );
                 }),
               );
+            }
+
+            if (shouldRetryConfirmation && order) {
+              const draftOrderIds = order.draftOrderIds || {};
+              if (Object.keys(draftOrderIds).length > 0) {
+                console.log('[Printful Webhook] Retrying draft order confirmation', { orderId: order.id, draftOrderIds });
+                const confirmationResults: Record<string, { success: boolean; error?: string }> = {};
+                for (const [providerName, draftId] of Object.entries(draftOrderIds)) {
+                  if (providerName === 'manual') continue;
+                  const provider = runtime.getProvider(providerName);
+                  if (!provider) {
+                    confirmationResults[providerName] = { success: false, error: 'Provider not configured' };
+                    continue;
+                  }
+                  try {
+                    await managedRuntime.runPromise(
+                      Effect.tryPromise({
+                        try: () => provider.client.confirmOrder({ id: draftId as string }),
+                        catch: (e) => new Error(`Failed to confirm: ${e instanceof Error ? e.message : String(e)}`),
+                      }).pipe(Effect.retry({ times: 3, schedule: Schedule.exponential('100 millis') })),
+                    );
+                    confirmationResults[providerName] = { success: true };
+                  } catch (error) {
+                    const errorMsg = error instanceof Error ? error.message : String(error);
+                    console.warn('[Printful Webhook] Confirmation retry failed', { providerName, draftId, error: errorMsg });
+                    confirmationResults[providerName] = { success: false, error: errorMsg };
+                  }
+                }
+                const allSuccess = Object.values(confirmationResults).every((r) => r.success);
+                const finalStatus = allSuccess ? 'processing' : 'paid_pending_fulfillment';
+                await managedRuntime.runPromise(
+                  Effect.gen(function* () {
+                    const store = yield* OrderStore;
+                    yield* store.updateStatus(
+                      order.id,
+                      finalStatus,
+                      'service:printful',
+                      `fulfillment:retry_${allSuccess ? 'confirmed' : 'partial'}`,
+                      { confirmationResults, allSuccess },
+                    );
+                  }),
+                );
+              }
             }
 
             if (newTracking && order) {
@@ -1553,6 +1597,36 @@ export default createPlugin({
           const maxAgeHours = input?.maxAgeHours || 24;
           const exit = await managedRuntime.runPromiseExit(
             cleanupAbandonedDrafts(runtime, maxAgeHours),
+          );
+
+          if (Exit.isFailure(exit)) {
+            const error = Cause.squash(exit.cause);
+            if (error instanceof ORPCError) {
+              throw error;
+            }
+            throw new ORPCError("INTERNAL_SERVER_ERROR", {
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+
+          return exit.value;
+        },
+      ),
+
+      retryPendingConfirmations: builder.retryPendingConfirmations.handler(
+        async ({ input, context }) => {
+          const cronSecret = context.reqHeaders?.get("x-cron-secret");
+          const expectedSecret = process.env.CRON_SECRET;
+
+          if (!expectedSecret || cronSecret !== expectedSecret) {
+            throw new ORPCError("UNAUTHORIZED", {
+              message: "Invalid or missing cron secret",
+            });
+          }
+
+          const olderThanMinutes = input?.olderThanMinutes || 5;
+          const exit = await managedRuntime.runPromiseExit(
+            retryPendingConfirmations(runtime, olderThanMinutes),
           );
 
           if (Exit.isFailure(exit)) {

--- a/api/src/jobs/retry-confirmations.ts
+++ b/api/src/jobs/retry-confirmations.ts
@@ -1,0 +1,125 @@
+import { Effect, Schedule } from 'every-plugin/effect';
+import { OrderStore } from '../store/orders';
+import type { MarketplaceRuntime } from '../runtime';
+
+export interface RetryConfirmationResult {
+  totalProcessed: number;
+  confirmed: number;
+  stillPending: number;
+  failed: number;
+  errors: Array<{ orderId: string; provider: string; error: string }>;
+}
+
+export const retryPendingConfirmations = (
+  runtime: MarketplaceRuntime,
+  olderThanMinutes = 5
+) => Effect.gen(function* () {
+  const orderStore = yield* OrderStore;
+  console.log(`[RetryConfirmationJob] Starting retry of paid_pending_fulfillment orders older than ${olderThanMinutes} minutes`);
+
+  const pendingOrders = yield* orderStore.findPendingConfirmation(olderThanMinutes);
+
+  console.log(`[RetryConfirmationJob] Found ${pendingOrders.length} orders pending fulfillment confirmation`);
+
+  if (pendingOrders.length === 0) {
+    return {
+      totalProcessed: 0,
+      confirmed: 0,
+      stillPending: 0,
+      failed: 0,
+      errors: [],
+    } as RetryConfirmationResult;
+  }
+
+  let confirmed = 0;
+  let stillPending = 0;
+  let failed = 0;
+  const errors: Array<{ orderId: string; provider: string; error: string }> = [];
+
+  for (const order of pendingOrders) {
+    console.log(`[RetryConfirmationJob] Processing order ${order.id}`);
+
+    if (!order.draftOrderIds || Object.keys(order.draftOrderIds).length === 0) {
+      console.warn(`[RetryConfirmationJob] Order ${order.id} has no draft order IDs, skipping`);
+      stillPending++;
+      continue;
+    }
+
+    const confirmationResults: Array<{ provider: string; success: boolean; error?: string }> = [];
+
+    for (const [providerName, draftId] of Object.entries(order.draftOrderIds)) {
+      if (providerName === 'manual') {
+        confirmationResults.push({ provider: providerName, success: true });
+        continue;
+      }
+
+      const provider = runtime.getProvider(providerName);
+
+      if (!provider) {
+        console.error(`[RetryConfirmationJob] Provider ${providerName} not found for order ${order.id}`);
+        confirmationResults.push({
+          provider: providerName,
+          success: false,
+          error: 'Provider not found',
+        });
+        errors.push({
+          orderId: order.id,
+          provider: providerName,
+          error: 'Provider not found',
+        });
+        continue;
+      }
+
+      const confirmResult = yield* Effect.tryPromise({
+        try: () => provider.client.confirmOrder({ id: draftId }),
+        catch: (e) => e instanceof Error ? e : new Error(String(e)),
+      }).pipe(
+        Effect.retry({ times: 3, schedule: Schedule.exponential('100 millis') }),
+        Effect.map(() => ({ provider: providerName, success: true })),
+        Effect.catchAll((error) => Effect.succeed({
+          provider: providerName,
+          success: false,
+          error: error.message,
+        }))
+      );
+
+      if (confirmResult.success) {
+        console.log(`[RetryConfirmationJob] Successfully confirmed draft ${draftId} at ${providerName} for order ${order.id}`);
+      } else {
+        const errorMessage = 'error' in confirmResult ? confirmResult.error : 'Unknown error';
+        console.error(`[RetryConfirmationJob] Failed to confirm draft ${draftId} at ${providerName} for order ${order.id}:`, errorMessage);
+        errors.push({
+          orderId: order.id,
+          provider: providerName,
+          error: errorMessage,
+        });
+      }
+
+      confirmationResults.push(confirmResult);
+    }
+
+    const allSucceeded = confirmationResults.every(r => r.success);
+
+    if (allSucceeded) {
+      yield* orderStore.updateStatus(order.id, 'processing', 'job:retry_confirmation', 'fulfillment:confirmed');
+      confirmed++;
+      console.log(`[RetryConfirmationJob] Order ${order.id} fully confirmed`);
+    } else {
+      yield* orderStore.updateStatus(order.id, 'paid_pending_fulfillment', 'job:retry_confirmation', 'fulfillment:retry_partial', { confirmationResults });
+      stillPending++;
+      console.warn(`[RetryConfirmationJob] Order ${order.id} still has unconfirmed drafts`);
+    }
+  }
+
+  const result: RetryConfirmationResult = {
+    totalProcessed: pendingOrders.length,
+    confirmed,
+    stillPending,
+    failed,
+    errors,
+  };
+
+  console.log(`[RetryConfirmationJob] Retry completed:`, result);
+
+  return result;
+});

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -75,6 +75,7 @@ export const ProductVariantSchema = z.object({
   fulfillmentConfig: FulfillmentConfigSchema.optional(),
   availableForSale: z.boolean().default(true),
   inventoryQuantity: z.number().optional(),
+  fulfillmentCost: z.number().optional(),
 });
 
 export const CollectionFeaturedProductSchema = z.object({
@@ -191,6 +192,7 @@ export const ProductSchema = z.object({
   source: z.string().optional(),
   vendor: z.string().optional(),
   listed: z.boolean().default(true),
+  priceLocked: z.boolean().default(false),
   assetId: z.string().optional(),
   metadata: ProductMetadataSchema.optional(),
 });
@@ -412,6 +414,7 @@ export const ProductVariantInputSchema = z.object({
   externalVariantId: z.string().optional(),
   fulfillmentConfig: FulfillmentConfigSchema.optional(),
   inStock: z.boolean().optional(),
+  fulfillmentCost: z.number().optional(),
 });
 
 export const ProductWithImagesSchema = z.object({

--- a/api/src/services/fulfillment/printful/client.ts
+++ b/api/src/services/fulfillment/printful/client.ts
@@ -278,7 +278,7 @@ export class PrintfulClient {
       };
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
-      console.log(`[PrintfulClient] Catalog product ${productId} not available: ${errorMessage}`);
+      console.warn(`[PrintfulClient] Catalog product ${productId} not available: ${errorMessage}. Variant fulfillment files will lack technique metadata — orders will need to resolve techniques at creation time.`);
       return null;
     }
   }

--- a/api/src/services/fulfillment/printful/client.ts
+++ b/api/src/services/fulfillment/printful/client.ts
@@ -11,6 +11,34 @@ import { FulfillmentError } from '../errors';
 
 export type { Address, CatalogItem, Order, Shipment, Variant } from 'printful-sdk-js-v2';
 
+export interface TechniquePrice {
+  technique: string;
+  price: number;
+  discountedPrice: number;
+}
+
+export interface PlacementPrice {
+  placement: string;
+  technique: string;
+  price: number;
+  discountedPrice: number;
+}
+
+export interface VariantPricing {
+  techniques: TechniquePrice[];
+  placements: PlacementPrice[];
+  currency: string;
+}
+
+export interface PrintfulProviderConfig {
+  catalogVariantId: number;
+  catalogProductId: number;
+  technique?: string;
+  techniquePrice?: number;
+  placementPricing?: Record<string, number>;
+  fulfillmentCost?: number;
+}
+
 export interface PrintfulSyncProduct {
   id: number;
   external_id: string;
@@ -292,11 +320,7 @@ export class PrintfulClient {
     return (data?.data ?? []) as Variant[];
   }
 
-  async getVariantPrice(variantId: number): Promise<{
-    wholesale: number;
-    retail: number;
-    currency: string;
-  } | null> {
+  async getVariantPrice(variantId: number): Promise<VariantPricing | null> {
     try {
       const result = await this.executeWithRetry(
         () => this.sdk.catalogV2.getVariantPricesById(variantId),
@@ -304,15 +328,71 @@ export class PrintfulClient {
       );
       const data = result as { data?: any };
       if (!data?.data) return null;
-      return {
-        wholesale: parseFloat(data.data.wholesale_price ?? '0'),
-        retail: parseFloat(data.data.retail_price ?? '0'),
-        currency: data.data.currency ?? 'USD',
-      };
+      return this.parsePricingResponse(data.data);
     } catch (e) {
       console.log(`[PrintfulClient] Variant price ${variantId} not available: ${e instanceof Error ? e.message : String(e)}`);
       return null;
     }
+  }
+
+  async getVariantPricesBatch(variantIds: number[]): Promise<Map<number, VariantPricing>> {
+    const results = new Map<number, VariantPricing>();
+    await Effect.runPromise(
+      Effect.forEach(variantIds, (variantId) =>
+        Effect.tryPromise({
+          try: async () => {
+            const price = await this.getVariantPrice(variantId);
+            if (price) results.set(variantId, price);
+          },
+          catch: () => {},
+        })
+      , { concurrency: 5 })
+    );
+    return results;
+  }
+
+  async getProductPrices(productId: number): Promise<VariantPricing | null> {
+    try {
+      const result = await this.executeWithRetry(
+        () => this.sdk.catalogV2.getProductPricesById(productId),
+        `getProductPrices(${productId})`
+      );
+      const data = result as { data?: any };
+      if (!data?.data) return null;
+      return this.parsePricingResponse(data.data);
+    } catch (e) {
+      console.warn(`[PrintfulClient] Product prices ${productId} not available: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    }
+  }
+
+  private parsePricingResponse(d: any): VariantPricing {
+    const techniques: TechniquePrice[] = [];
+    if (Array.isArray(d.variant?.techniques)) {
+      for (const t of d.variant.techniques) {
+        techniques.push({
+          technique: t.technique_key,
+          price: parseFloat(t.price ?? '0'),
+          discountedPrice: parseFloat(t.discounted_price ?? '0'),
+        });
+      }
+    }
+
+    const placements: PlacementPrice[] = [];
+    if (Array.isArray(d.product?.placements)) {
+      for (const p of d.product.placements) {
+        if (p.id && p.technique_key) {
+          placements.push({
+            placement: p.id,
+            technique: p.technique_key,
+            price: parseFloat(p.price ?? '0'),
+            discountedPrice: parseFloat(p.discounted_price ?? '0'),
+          });
+        }
+      }
+    }
+
+    return { techniques, placements, currency: d.currency ?? 'USD' };
   }
 
   async getCatalogVariant(variantId: number): Promise<Variant | null> {

--- a/api/src/services/fulfillment/printful/service.ts
+++ b/api/src/services/fulfillment/printful/service.ts
@@ -381,6 +381,31 @@ export class PrintfulService {
           tax_number: input.recipient.taxId,
         };
 
+        const itemsWithMissingTechnique = input.items.filter(item =>
+          (item.files || []).some((df: any) => !df.metadata?.technique),
+        );
+        const catalogProductsByProductId = new Map<number, {
+          placementTechniques?: Record<string, string>;
+          primaryPlacement?: { name: string; technique: string };
+        } | null>();
+
+        if (itemsWithMissingTechnique.length > 0) {
+          const productIds = new Set<number>();
+          for (const item of itemsWithMissingTechnique) {
+            const config = item.providerConfig as { catalogProductId?: number };
+            if (config?.catalogProductId) productIds.add(config.catalogProductId);
+          }
+          for (const productId of productIds) {
+            if (!catalogProductsByProductId.has(productId)) {
+              const catalogProduct = await this.client.getCatalogProduct(productId);
+              catalogProductsByProductId.set(productId, catalogProduct);
+              if (!catalogProduct) {
+                console.warn(`[PrintfulService.createOrder] Catalog product ${productId} not available — cannot resolve missing techniques`);
+              }
+            }
+          }
+        }
+
         const orderItems = input.items.map(item => {
           const config = item.providerConfig as {
             catalogVariantId?: number;
@@ -396,18 +421,52 @@ export class PrintfulService {
           }
 
           const placements = (item.files || [])
-            .filter((df: any) => df.metadata?.technique)
-            .map((df: any) => ({
-              placement: df.slot,
-              technique: df.metadata.technique,
-              layers: [{ type: 'file' as const, url: df.url }],
+            .filter((df: any) => df.url)
+            .map((df: any) => {
+              const slot = df.slot || 'default';
+              let technique = df.metadata?.technique as string | undefined;
+
+              if (!technique) {
+                const catalogProduct = catalogProductsByProductId.get(config.catalogProductId!) ?? null;
+                if (slot === 'default') {
+                  technique = catalogProduct?.primaryPlacement?.technique;
+                } else {
+                  technique = catalogProduct?.placementTechniques?.[slot]
+                    ?? catalogProduct?.primaryPlacement?.technique;
+                }
+                if (technique) {
+                  console.info(`[PrintfulService.createOrder] Resolved technique "${technique}" for placement "${slot}" from catalog product ${config.catalogProductId}`);
+                } else {
+                  console.warn(`[PrintfulService.createOrder] Could not resolve technique for placement "${slot}" on catalog product ${config.catalogProductId} — file will be skipped`);
+                }
+              }
+
+              return {
+                placement: slot,
+                technique,
+                url: df.url,
+              };
+            })
+            .filter((p): p is { placement: string; technique: string; url: string } => !!p.technique)
+            .map(p => ({
+              placement: p.placement,
+              technique: p.technique,
+              layers: [{ type: 'file' as const, url: p.url }],
             }));
+
+          if (placements.length === 0) {
+            throw new FulfillmentError({
+              message: `No valid placements for catalog variant ${catalogVariantId} — design files are missing or technique could not be resolved. Ensure product was synced with catalog placement data.`,
+              code: 'INVALID_REQUEST',
+              provider: 'printful',
+            });
+          }
 
           return {
             source: 'catalog' as const,
             catalog_variant_id: catalogVariantId,
             quantity: item.quantity,
-            ...(placements.length > 0 ? { placements } : {}),
+            placements,
           };
         });
 
@@ -700,6 +759,11 @@ export class PrintfulService {
         let catalogProduct: Awaited<ReturnType<typeof this.client.getCatalogProduct>> = null;
         if (catalogProductId) {
           catalogProduct = await this.client.getCatalogProduct(catalogProductId);
+          if (!catalogProduct) {
+            console.warn(`[PrintfulService.syncProducts] Catalog product ${catalogProductId} not available for "${sync_product.name}" — placement/technique data will be missing. Orders for these variants will resolve techniques at creation time.`);
+          }
+        } else {
+          console.warn(`[PrintfulService.syncProducts] No catalogProductId found for "${sync_product.name}" — placement/technique data will be missing.`);
         }
 
         yield {
@@ -781,8 +845,13 @@ export class PrintfulService {
     catalogPlacements: {
       placementTechniques?: Record<string, string>;
       primaryPlacement?: { name: string; technique: string };
-    } | null
+    } | null,
+    syncProductName?: string
   ): FulfillmentFile[] {
+    if (!catalogPlacements) {
+      console.warn(`[PrintfulService.extractDesignFiles] No catalog placement data for "${syncProductName ?? 'unknown'}" — technique metadata will be missing. Orders for these variants will need to resolve techniques at creation time.`);
+    }
+
     const bySlot = new Map<string, { file: typeof files[number]; slot: string; technique: string | null; resolvedUrl: string }>();
 
     for (const f of files) {
@@ -800,7 +869,7 @@ export class PrintfulService {
         slot = type;
         technique = catalogPlacements.placementTechniques[type];
       } else {
-        slot = type;
+        slot = type || 'default';
         technique = catalogPlacements?.placementTechniques?.[slot] ?? null;
       }
 
@@ -808,6 +877,10 @@ export class PrintfulService {
 
       const resolvedUrl = f.url || f.preview_url || f.thumbnail_url || null;
       if (!resolvedUrl) continue;
+
+      if (!technique) {
+        console.warn(`[PrintfulService.extractDesignFiles] No technique resolved for file ${f.id} (type="${type}", slot="${slot}") on "${syncProductName ?? 'unknown'}" — this will need resolution at order time`);
+      }
 
       bySlot.set(slot, { file: f, slot, technique, resolvedUrl });
     }
@@ -861,7 +934,7 @@ export class PrintfulService {
         optionsMap.get('Color')!.add(catalogVariant.color);
       }
 
-      const designFiles = this.extractDesignFiles(v.files, catalogProduct);
+      const designFiles = this.extractDesignFiles(v.files, catalogProduct, syncProduct.name);
 
       const fulfillmentConfig: FulfillmentConfig = {
         providerName: 'printful',

--- a/api/src/services/fulfillment/printful/service.ts
+++ b/api/src/services/fulfillment/printful/service.ts
@@ -34,7 +34,7 @@ import type {
   TaxQuoteOutput,
   VariantPriceOutput,
 } from '../schema';
-import { PrintfulClient, type PrintfulSyncProduct, type PrintfulSyncVariant } from './client';
+import { PrintfulClient, type PrintfulSyncProduct, type PrintfulSyncVariant, type VariantPricing } from './client';
 import type { MockupStyleInfo } from './types';
 import type { ProductWithImages, ProductVariantInput, Product, FulfillmentConfig } from '../../../schema';
 import type { SyncProgressEvent } from '../schema';
@@ -185,8 +185,12 @@ export class PrintfulService {
       try: async () => {
         const providerRef = input.id.replace('printful-', '');
         const price = await this.client.getVariantPrice(parseInt(providerRef, 10));
+        if (!price) return { price: null };
+        const primaryTechnique = price.techniques[0];
         return {
-          price: price ? { wholesale: price.wholesale, retail: price.retail, currency: price.currency } : null,
+          price: primaryTechnique
+            ? { cost: primaryTechnique.price, discountedCost: primaryTechnique.discountedPrice || primaryTechnique.price, currency: price.currency }
+            : null,
         };
       },
       catch: (e) => new FulfillmentError({
@@ -752,7 +756,7 @@ export class PrintfulService {
         const detail = await this.client.getSyncProduct(syncProduct.id);
         const { sync_product, sync_variants } = detail;
 
-        const variantIds = sync_variants.map(v => v.variant_id).filter(Boolean);
+        const variantIds = sync_variants.map(v => v.variant_id).filter(id => id > 0);
         const catalogVariants = await this.client.getCatalogVariantsBatch(variantIds);
 
         const catalogProductId = sync_variants[0]?.product?.product_id;
@@ -764,6 +768,19 @@ export class PrintfulService {
           }
         } else {
           console.warn(`[PrintfulService.syncProducts] No catalogProductId found for "${sync_product.name}" — placement/technique data will be missing.`);
+        }
+
+        let variantPrices: Map<number, VariantPricing> = new Map();
+        let productPrices: Awaited<ReturnType<typeof this.client.getProductPrices>> = null;
+        if (catalogProductId) {
+          try {
+            [variantPrices, productPrices] = await Promise.all([
+              this.client.getVariantPricesBatch(variantIds),
+              this.client.getProductPrices(catalogProductId),
+            ]);
+          } catch (e) {
+            console.warn(`[PrintfulService.syncProducts] Failed to fetch pricing data for "${sync_product.name}": ${e instanceof Error ? e.message : String(e)}`);
+          }
         }
 
         yield {
@@ -781,7 +798,9 @@ export class PrintfulService {
           sync_product,
           sync_variants,
           catalogVariants,
-          catalogProduct
+          catalogProduct,
+          variantPrices,
+          productPrices
         );
 
         const result = await upsertProduct(productWithImages, new Date());
@@ -919,7 +938,9 @@ export class PrintfulService {
       placements?: string[];
       placementTechniques?: Record<string, string>;
       primaryPlacement?: { name: string; technique: string };
-    } | null
+    } | null,
+    variantPrices?: Map<number, VariantPricing>,
+    productPrices?: VariantPricing | null
   ): ProductWithImages {
     const optionsMap = new Map<string, Set<string>>();
     const variants = syncVariants.map(v => {
@@ -936,11 +957,45 @@ export class PrintfulService {
 
       const designFiles = this.extractDesignFiles(v.files, catalogProduct, syncProduct.name);
 
+      const variantPrice = variantPrices?.get(v.variant_id);
+      const activePlacements = designFiles
+        .filter(df => df.metadata?.technique && df.slot)
+        .map(df => ({ slot: df.slot!, technique: String(df.metadata!.technique) }));
+
+      let matchedTechnique: string | null = catalogProduct?.primaryPlacement?.technique ?? null;
+      if (activePlacements.length > 0) {
+        matchedTechnique = activePlacements[0]!.technique;
+      }
+
+      const techniquePrice = matchedTechnique
+        ? variantPrice?.techniques.find(t => t.technique === matchedTechnique)?.price ?? 0
+        : 0;
+
+      const primaryPlacementSlot = activePlacements.length > 0 ? activePlacements[0]!.slot : null;
+      const additionalPlacementCost = activePlacements
+        .filter(p => p.slot !== primaryPlacementSlot)
+        .reduce((sum, p) => {
+          const placementPrice = variantPrice?.placements.find(pl => pl.placement === p.slot)?.price
+            ?? productPrices?.placements.find(pl => pl.placement === p.slot)?.price;
+          if (placementPrice !== undefined) return sum + placementPrice;
+          return sum;
+        }, 0);
+
+      const fulfillmentCost = techniquePrice + additionalPlacementCost;
+
+      const allPlacementPricing: Record<string, number> = {};
+      for (const p of variantPrice?.placements ?? productPrices?.placements ?? []) {
+        allPlacementPricing[p.placement] = p.price;
+      }
+
       const fulfillmentConfig: FulfillmentConfig = {
         providerName: 'printful',
         providerConfig: {
           catalogVariantId: v.variant_id,
           catalogProductId: v.product.product_id,
+          ...(matchedTechnique ? { technique: matchedTechnique, techniquePrice } : {}),
+          ...(Object.keys(allPlacementPricing).length > 0 ? { placementPricing: allPlacementPricing } : {}),
+          ...(fulfillmentCost > 0 ? { fulfillmentCost } : {}),
         },
         files: designFiles,
       };
@@ -959,6 +1014,7 @@ export class PrintfulService {
         externalVariantId: String(v.variant_id),
         fulfillmentConfig,
         inStock: v.synced,
+        fulfillmentCost: fulfillmentCost > 0 ? fulfillmentCost : undefined,
       };
     });
 
@@ -1236,5 +1292,65 @@ export class PrintfulService {
 
       return images;
     });
+  }
+
+  async handleCatalogPriceChange(
+    catalogProductId: string,
+    productStore: {
+      findByExternalProductId: (externalProductId: string, fulfillmentProvider: string) => Effect.Effect<Product | null, Error>;
+      upsert: (product: ProductWithImages, syncedAt?: Date) => Effect.Effect<Product & { isNew: boolean }, Error>;
+    },
+  ): Promise<void> {
+    const product = await Effect.runPromise(
+      productStore.findByExternalProductId(catalogProductId, 'printful'),
+    ).catch(() => null);
+
+    if (!product) {
+      console.log(`[Printful] No local product found for catalog product ${catalogProductId}, skipping price update`);
+      return;
+    }
+
+    console.log(`[Printful] Catalog price changed for product ${product.id} (catalog: ${catalogProductId}), re-syncing`);
+
+    try {
+      const detail = await this.client.getSyncProduct(catalogProductId);
+      const { sync_product, sync_variants } = detail;
+
+      const variantIds = sync_variants.map(v => v.variant_id).filter(id => id > 0);
+      const catalogVariants = await this.client.getCatalogVariantsBatch(variantIds);
+
+      let catalogProduct: Awaited<ReturnType<typeof this.client.getCatalogProduct>> = null;
+      if (catalogProductId) {
+        catalogProduct = await this.client.getCatalogProduct(parseInt(catalogProductId, 10));
+      }
+
+      let variantPrices: Map<number, VariantPricing> = new Map();
+      let productPrices: Awaited<ReturnType<typeof this.client.getProductPrices>> = null;
+      if (catalogProductId) {
+        try {
+          [variantPrices, productPrices] = await Promise.all([
+            this.client.getVariantPricesBatch(variantIds),
+            this.client.getProductPrices(parseInt(catalogProductId, 10)),
+          ]);
+        } catch (e) {
+          console.warn(`[Printful] Failed to fetch pricing data for catalog_price_changed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+
+      const transformed = this.transformSyncProductToV2(
+        sync_product,
+        sync_variants,
+        catalogVariants,
+        catalogProduct,
+        variantPrices,
+        productPrices,
+      );
+
+      await Effect.runPromise(
+        productStore.upsert(transformed, new Date()),
+      );
+    } catch (error) {
+      console.error(`[Printful] Failed to re-sync product after catalog price change: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 }

--- a/api/src/services/fulfillment/printful/webhook.ts
+++ b/api/src/services/fulfillment/printful/webhook.ts
@@ -4,10 +4,13 @@ import type { OrderStatus, TrackingInfo } from '../../../schema';
 
 type PrintfulWebhookPayload = {
   type?: string;
-  data?: {
+  data?: { 
     order?: { 
       external_id?: string;
       status?: string;
+    };
+    catalog_product?: {
+      id?: number;
     };
     shipment?: {
       tracking_number?: string;
@@ -49,6 +52,7 @@ export function verifyPrintfulWebhookSignature(options: {
 export function parsePrintfulWebhook(rawBody: string): {
   eventType: string;
   externalId?: string;
+  catalogProductId?: number;
   data?: PrintfulWebhookPayload['data'];
 } {
   let payload: PrintfulWebhookPayload;
@@ -61,6 +65,7 @@ export function parsePrintfulWebhook(rawBody: string): {
   return {
     eventType: payload.type || 'unknown',
     externalId: payload.data?.order?.external_id,
+    catalogProductId: payload.data?.catalog_product?.id,
     data: payload.data,
   };
 }

--- a/api/src/services/fulfillment/printful/webhook.ts
+++ b/api/src/services/fulfillment/printful/webhook.ts
@@ -69,11 +69,12 @@ export function computePrintfulUpdate(options: {
   eventType: string;
   data: PrintfulWebhookPayload['data'] | undefined;
   currentStatus: OrderStatus;
-}): { newStatus?: OrderStatus; newTracking?: TrackingInfo[] } {
+}): { newStatus?: OrderStatus; newTracking?: TrackingInfo[]; shouldRetryConfirmation?: boolean } {
   const { eventType, data, currentStatus } = options;
 
   let newStatus: OrderStatus | undefined;
   let newTracking: TrackingInfo[] | undefined;
+  let shouldRetryConfirmation = false;
 
   switch (eventType) {
     case 'order_created':
@@ -89,8 +90,14 @@ export function computePrintfulUpdate(options: {
           newStatus = 'shipped';
           break;
         case 'pending':
+        case 'inprocess':
           if (currentStatus === 'paid' || currentStatus === 'paid_pending_fulfillment') {
             newStatus = 'processing';
+          }
+          break;
+        case 'draft':
+          if (currentStatus === 'paid_pending_fulfillment') {
+            shouldRetryConfirmation = true;
           }
           break;
         case 'canceled':
@@ -173,5 +180,5 @@ export function computePrintfulUpdate(options: {
       break;
   }
 
-  return { newStatus, newTracking };
+  return { newStatus, newTracking, shouldRetryConfirmation };
 }

--- a/api/src/services/fulfillment/schema.ts
+++ b/api/src/services/fulfillment/schema.ts
@@ -29,8 +29,8 @@ export const CatalogSlotSchema = z.object({
 });
 
 export const ProviderCatalogPriceSchema = z.object({
-  wholesale: z.number().optional(),
-  retail: z.number().optional(),
+  cost: z.number().optional(),
+  discountedCost: z.number().optional(),
   currency: z.string().optional(),
 });
 

--- a/api/src/services/payment/pingpay/webhook.ts
+++ b/api/src/services/payment/pingpay/webhook.ts
@@ -127,12 +127,22 @@ export function handlePingPayWebhookEffect(options: {
               return { success: true } as const;
             }),
             Effect.catchAll((error) => {
-              console.error('[PingPay Webhook] Order confirmation failed', {
-                providerName,
-                draftId,
-                error: error.message,
-              });
-              return Effect.succeed({ success: false as const, error: error.message });
+              const errorMsg = error.message || String(error);
+              const isCostCalculationPending = /calculat|cost.*pending|not.*possible.*confirm/i.test(errorMsg);
+              if (isCostCalculationPending) {
+                console.warn('[PingPay Webhook] Order confirmation failed — Printful costs still calculating. Order will remain in paid_pending_fulfillment for retry job.', {
+                  providerName,
+                  draftId,
+                  error: errorMsg,
+                });
+              } else {
+                console.error('[PingPay Webhook] Order confirmation failed', {
+                  providerName,
+                  draftId,
+                  error: errorMsg,
+                });
+              }
+              return Effect.succeed({ success: false as const, error: errorMsg, isCostCalculationPending });
             })
           );
 

--- a/api/src/store/orders.ts
+++ b/api/src/store/orders.ts
@@ -20,6 +20,7 @@ export class OrderStore extends Context.Tag("OrderStore")<
     readonly findByCheckoutSession: (checkoutSessionId: string) => Effect.Effect<OrderWithItems | null, Error>;
     readonly findByFulfillmentRef: (fulfillmentReferenceId: string) => Effect.Effect<OrderWithItems | null, Error>;
     readonly findAbandonedDrafts: (olderThanHours: number) => Effect.Effect<OrderWithItems[], Error>;
+    readonly findPendingConfirmation: (olderThanMinutes?: number) => Effect.Effect<OrderWithItems[], Error>;
     readonly updateCheckout: (orderId: string, checkoutSessionId: string, checkoutProvider: 'stripe' | 'near' | 'pingpay') => Effect.Effect<OrderWithItems, Error>;
     readonly updateDraftOrderIds: (orderId: string, draftOrderIds: Record<string, string>) => Effect.Effect<OrderWithItems, Error>;
     readonly updatePaymentDetails: (orderId: string, paymentDetails: Record<string, unknown>) => Effect.Effect<OrderWithItems, Error>;
@@ -340,6 +341,27 @@ export const OrderStoreLive = Layer.effect(
             return await Promise.all(abandoned.map(rowToOrder));
           },
           catch: (error) => new Error(`Failed to find abandoned drafts: ${error}`),
+        }),
+
+      findPendingConfirmation: (olderThanMinutes = 5) =>
+        Effect.tryPromise({
+          try: async () => {
+            const cutoffTime = new Date(Date.now() - olderThanMinutes * 60 * 1000);
+
+            const results = await db
+              .select()
+              .from(schema.orders)
+              .where(and(
+                eq(schema.orders.status, 'paid_pending_fulfillment'),
+                eq(schema.orders.isDeleted, false)
+              ))
+              .orderBy(desc(schema.orders.createdAt));
+
+            const pending = results.filter(order => order.createdAt < cutoffTime);
+
+            return await Promise.all(pending.map(rowToOrder));
+          },
+          catch: (error) => new Error(`Failed to find pending confirmation orders: ${error}`),
         }),
 
       updateCheckout: (orderId, checkoutSessionId, checkoutProvider) =>

--- a/api/src/store/products.ts
+++ b/api/src/store/products.ts
@@ -12,6 +12,7 @@ import type {
   ProductWithImages,
 } from "../schema";
 import { Database } from "./database";
+import type { PrintfulProviderConfig } from '../services/fulfillment/printful/client';
 
 export class ProductStore extends Context.Tag("ProductStore")<
   ProductStore,
@@ -19,6 +20,10 @@ export class ProductStore extends Context.Tag("ProductStore")<
     readonly find: (identifier: string) => Effect.Effect<Product | null, Error>;
     readonly findByPublicKey: (
       publicKey: string,
+    ) => Effect.Effect<Product | null, Error>;
+    readonly findByExternalProductId: (
+      externalProductId: string,
+      fulfillmentProvider: string,
     ) => Effect.Effect<Product | null, Error>;
     readonly findMany: (
       criteria: ProductCriteria,
@@ -58,6 +63,7 @@ export class ProductStore extends Context.Tag("ProductStore")<
         name?: string;
         description?: string | null;
         price?: number;
+        priceLocked?: boolean;
         images?: ProductImage[];
         thumbnailImage?: string | null;
       },
@@ -98,17 +104,22 @@ export const ProductStoreLive = Layer.effect(
         .from(schema.productVariants)
         .where(eq(schema.productVariants.productId, productId));
 
-      return variants.map((v) => ({
-        id: v.id,
-        title: v.name,
-        sku: v.sku || undefined,
-        price: v.price / 100,
-        currency: v.currency,
-        attributes: v.attributes || [],
-        externalVariantId: v.externalVariantId || undefined,
-        fulfillmentConfig: v.fulfillmentConfig || undefined,
-        availableForSale: v.inStock,
-      }));
+      return variants.map((v) => {
+        const fc = v.fulfillmentConfig as { providerName?: string; providerConfig?: PrintfulProviderConfig } | null;
+        const fulfillmentCost = fc?.providerConfig?.fulfillmentCost;
+        return {
+          id: v.id,
+          title: v.name,
+          sku: v.sku || undefined,
+          price: v.price / 100,
+          currency: v.currency,
+          attributes: v.attributes || [],
+          externalVariantId: v.externalVariantId || undefined,
+          fulfillmentConfig: v.fulfillmentConfig || undefined,
+          availableForSale: v.inStock,
+          fulfillmentCost,
+        };
+      });
     };
 
     const getProductCollections = async (
@@ -219,6 +230,7 @@ export const ProductStoreLive = Layer.effect(
         source: row.source,
         thumbnailImage: row.thumbnailImage || undefined,
         listed: row.listed ?? true,
+        priceLocked: row.priceLocked ?? false,
         assetId: row.assetId || undefined,
         metadata: row.metadata || undefined,
       };
@@ -289,6 +301,30 @@ export const ProductStoreLive = Layer.effect(
           },
           catch: (error) =>
             new Error(`Failed to find product by publicKey: ${error}`),
+        }),
+
+      findByExternalProductId: (externalProductId, fulfillmentProvider) =>
+        Effect.tryPromise({
+          try: async () => {
+            const results = await db
+              .select()
+              .from(schema.products)
+              .where(
+                and(
+                  eq(schema.products.externalProductId, externalProductId),
+                  eq(schema.products.fulfillmentProvider, fulfillmentProvider),
+                ),
+              )
+              .limit(1);
+
+            if (results.length === 0) {
+              return null;
+            }
+
+            return await rowToProduct(results[0]!);
+          },
+          catch: (error) =>
+            new Error(`Failed to find product by externalProductId: ${error}`),
         }),
 
       findMany: (criteria) =>
@@ -441,6 +477,19 @@ export const ProductStoreLive = Layer.effect(
 
             const finalId = existingProduct?.id ?? product.id;
 
+            let existingVariantsByExtId = new Map<string, { price: number }>();
+            if (existingProduct && existingProduct.priceLocked) {
+              const existingVariants = await db
+                .select({ externalVariantId: schema.productVariants.externalVariantId, price: schema.productVariants.price })
+                .from(schema.productVariants)
+                .where(eq(schema.productVariants.productId, existingProduct.id));
+              for (const ev of existingVariants) {
+                if (ev.externalVariantId) {
+                  existingVariantsByExtId.set(ev.externalVariantId, { price: ev.price });
+                }
+              }
+            }
+
             if (existingProduct) {
               const existingMetadata = existingProduct.metadata as ProductMetadata | null;
               const newProviderDetails = product.metadata?.providerDetails;
@@ -457,7 +506,7 @@ export const ProductStoreLive = Layer.effect(
               await db
                 .update(schema.products)
                 .set({
-                  price: Math.round(product.price * 100),
+                  price: existingProduct.priceLocked ? existingProduct.price : Math.round(product.price * 100),
                   options: product.options,
                   thumbnailImage: product.thumbnailImage || existingProduct.thumbnailImage || null,
                   currency: product.currency,
@@ -477,19 +526,23 @@ export const ProductStoreLive = Layer.effect(
 
               if (product.variants.length > 0) {
                 await db.insert(schema.productVariants).values(
-                  product.variants.map((variant) => ({
-                    id: variant.id,
-                    productId: finalId,
-                    name: variant.name,
-                    sku: variant.sku || null,
-                    price: Math.round(variant.price * 100),
-                    currency: variant.currency,
-                    attributes: variant.attributes || null,
-                    externalVariantId: variant.externalVariantId || null,
-                    fulfillmentConfig: variant.fulfillmentConfig || null,
-                    inStock: variant.inStock ?? true,
-                    createdAt: now,
-                  })),
+                  product.variants.map((variant) => {
+                    const existingVariant = existingVariantsByExtId.get(variant.externalVariantId || '');
+                    const isPriceLocked = existingProduct.priceLocked ?? false;
+                    return {
+                      id: variant.id,
+                      productId: finalId,
+                      name: variant.name,
+                      sku: variant.sku || null,
+                      price: (isPriceLocked && existingVariant) ? existingVariant.price : Math.round(variant.price * 100),
+                      currency: variant.currency,
+                      attributes: variant.attributes || null,
+                      externalVariantId: variant.externalVariantId || null,
+                      fulfillmentConfig: variant.fulfillmentConfig || null,
+                      inStock: variant.inStock ?? true,
+                      createdAt: now,
+                    };
+                  }),
                 );
               }
 
@@ -765,6 +818,7 @@ export const ProductStoreLive = Layer.effect(
             if (data.name !== undefined) updateData.name = data.name;
             if (data.description !== undefined) updateData.description = data.description;
             if (data.price !== undefined) updateData.price = Math.round(data.price * 100);
+            if (data.priceLocked !== undefined) updateData.priceLocked = data.priceLocked;
             if (data.thumbnailImage !== undefined) updateData.thumbnailImage = data.thumbnailImage;
 
             await db

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "monorepo",

--- a/ui/src/integrations/api/admin.ts
+++ b/ui/src/integrations/api/admin.ts
@@ -113,6 +113,7 @@ export function useUpdateProduct() {
       name?: string;
       description?: string | null;
       price?: number;
+      priceLocked?: boolean;
       images?: Array<ProductImage>;
       thumbnailImage?: string | null;
     }) => {

--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory.tsx
@@ -29,6 +29,7 @@ import {
   GripVertical,
   ArrowUp,
   ArrowDown,
+  Lock,
 } from "lucide-react";
 import { ProductTitleCell } from "@/components/admin/product-title-cell";
 import { Button } from "@/components/ui/button";
@@ -927,6 +928,13 @@ function ExpandedProductPanel({
   );
 }
 
+function getMinFulfillmentCost(product: Product): number | null {
+  const costs = (product.variants ?? [])
+    .map((v) => v.fulfillmentCost)
+    .filter((c): c is number => typeof c === "number" && c > 0);
+  return costs.length > 0 ? Math.min(...costs) : null;
+}
+
 // Helper functions for time and date formatting
 function InventoryManagement() {
   const {
@@ -1139,11 +1147,74 @@ function InventoryManagement() {
         </Button>
       ),
       cell: ({ row }) => (
-        <span className="text-sm text-foreground/90 dark:text-muted-foreground">
+        <span className="text-sm text-foreground/90 dark:text-muted-foreground inline-flex items-center gap-1">
           ${row.original.price.toFixed(2)} {row.original.currency}
+          {row.original.priceLocked && (
+            <span title="Price locked"><Lock className="size-3 text-[#00EC97]" /></span>
+          )}
         </span>
       ),
-      size: 100,
+      size: 110,
+    },
+    {
+      id: "cost",
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          className="h-auto p-0 font-medium hover:bg-transparent"
+        >
+          Cost
+          <ArrowUpDown className="ml-2 size-4" />
+        </Button>
+      ),
+      accessorFn: (row) => getMinFulfillmentCost(row) ?? -1,
+      cell: ({ row }) => {
+        const cost = getMinFulfillmentCost(row.original);
+        if (cost === null) {
+          return <span className="text-sm text-foreground/40">—</span>;
+        }
+        return (
+          <span className="text-sm text-foreground/70 dark:text-muted-foreground">
+            ${cost.toFixed(2)}
+          </span>
+        );
+      },
+      size: 80,
+    },
+    {
+      id: "margin",
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          className="h-auto p-0 font-medium hover:bg-transparent"
+        >
+          Margin
+          <ArrowUpDown className="ml-2 size-4" />
+        </Button>
+      ),
+      accessorFn: (row) => {
+        const cost = getMinFulfillmentCost(row);
+        return cost !== null ? row.price - cost : -Infinity;
+      },
+      cell: ({ row }) => {
+        const cost = getMinFulfillmentCost(row.original);
+        if (cost === null) {
+          return <span className="text-sm text-foreground/40">—</span>;
+        }
+        const margin = row.original.price - cost;
+        return (
+          <span className={cn(
+            "text-sm font-medium",
+            margin > 0 && "text-[#00EC97]",
+            margin <= 0 && "text-red-500",
+          )}>
+            ${margin.toFixed(2)}
+          </span>
+        );
+      },
+      size: 90,
     },
     {
       accessorKey: "collections",

--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/$productId.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/$productId.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ExternalLink, ImagePlus, Loader2, Star, Trash2, Upload, GripVertical, X } from "lucide-react";
+import { ExternalLink, ImagePlus, Loader2, Lock, Star, Trash2, Unlock, Upload, GripVertical, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { DragDropProvider, DragOverlay, useDraggable, useDroppable } from "@dnd-kit/react";
 import { useProduct } from "@/integrations/api";
@@ -142,6 +142,7 @@ function ProductEditSheet() {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState("");
+  const [priceLocked, setPriceLocked] = useState(false);
   const [images, setImages] = useState<ProductImageDraft[]>([]);
   const [thumbnailImage, setThumbnailImage] = useState<string | null>(null);
   const [newImageUrl, setNewImageUrl] = useState("");
@@ -161,6 +162,7 @@ function ProductEditSheet() {
       setName(product.title);
       setDescription(product.description ?? "");
       setPrice(String(product.price));
+      setPriceLocked(product.priceLocked ?? false);
       setImages(
         (product.images ?? []).map((img, i) => ({
           id: img.id,
@@ -179,6 +181,7 @@ function ProductEditSheet() {
           title: product.title,
           description: product.description ?? "",
           price: product.price,
+          priceLocked: product.priceLocked ?? false,
           images: product.images ?? [],
           thumbnailImage: product.thumbnailImage ?? null,
         }),
@@ -192,6 +195,7 @@ function ProductEditSheet() {
         title: name,
         description,
         price: Number(price) || 0,
+        priceLocked,
         images,
         thumbnailImage,
       })
@@ -322,6 +326,7 @@ function ProductEditSheet() {
         name: name !== product.title ? name : undefined,
         description: description !== (product.description ?? "") ? description : undefined,
         price: parsedPrice !== product.price ? parsedPrice : undefined,
+        priceLocked: priceLocked !== (product.priceLocked ?? false) ? priceLocked : undefined,
         images: images.map((img, i) => ({
           id: img.id,
           url: img.url,
@@ -342,6 +347,7 @@ function ProductEditSheet() {
               title: name,
               description,
               price: parsedPrice,
+              priceLocked,
               images,
               thumbnailImage,
             }),
@@ -350,7 +356,7 @@ function ProductEditSheet() {
         },
       },
     );
-  }, [updateMutation, productId, name, description, price, images, thumbnailImage, product, queryClient]);
+  }, [updateMutation, productId, name, description, price, priceLocked, images, thumbnailImage, product, queryClient]);
 
   return (
     <Sheet open onOpenChange={(open) => { if (!open) handleClose(); }}>
@@ -418,8 +424,51 @@ function ProductEditSheet() {
                     </div>
                     <div className="space-y-2 w-40">
                       <Label htmlFor="price">Price (USD)</Label>
-                      <Input id="price" type="number" step="0.01" min="0" value={price} onChange={(e) => setPrice(e.target.value)} />
+                      <div className="flex items-center gap-2">
+                        <Input id="price" type="number" step="0.01" min="0" value={price} onChange={(e) => setPrice(e.target.value)} />
+                        <button
+                          type="button"
+                          onClick={() => setPriceLocked((v) => !v)}
+                          className={cn(
+                            "shrink-0 h-9 w-9 flex items-center justify-center rounded-md border transition-colors",
+                            priceLocked
+                              ? "border-[#00EC97] bg-[#00EC97]/10 text-[#00EC97]"
+                              : "border-border/60 bg-background/60 text-foreground/40 hover:text-foreground/70",
+                          )}
+                          title={priceLocked ? "Price locked — sync won't overwrite" : "Price unlocked — sync may overwrite"}
+                        >
+                          {priceLocked ? <Lock className="size-4" /> : <Unlock className="size-4" />}
+                        </button>
+                      </div>
+                      {priceLocked && (
+                        <p className="text-[11px] text-[#00EC97]">Locked — re-sync won't change your price</p>
+                      )}
                     </div>
+                    {(() => {
+                      const costs = (product.variants ?? [])
+                        .map((v) => v.fulfillmentCost)
+                        .filter((c): c is number => typeof c === "number" && c > 0);
+                      const minCost = costs.length > 0 ? Math.min(...costs) : null;
+                      const parsedPrice = Number(price) || 0;
+                      const margin = minCost !== null ? parsedPrice - minCost : null;
+                      if (minCost === null) return null;
+                      return (
+                        <div className="rounded-lg border border-border/40 bg-background/30 p-3 space-y-1.5">
+                          <p className="text-xs font-medium text-foreground/70">Fulfillment Cost</p>
+                          <p className="text-sm">${minCost.toFixed(2)}</p>
+                          <div className="flex items-center gap-2 pt-1 border-t border-border/30">
+                            <p className="text-xs font-medium text-foreground/70">Margin</p>
+                            <p className={cn(
+                              "text-sm font-semibold",
+                              margin !== null && margin > 0 && "text-[#00EC97]",
+                              margin !== null && margin <= 0 && "text-red-500",
+                            )}>
+                              {margin !== null ? `$${margin.toFixed(2)}` : "—"}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    })()}
                   </div>
                 </div>
 


### PR DESCRIPTION
When getCatalogProduct() fails during sync (rate limits, network errors), FulfillmentFile records end up without technique metadata. At order creation, files without technique were silently filtered out, producing blank-product orders with no placements. Additionally, when confirmOrder() fails because Printful costs are still calculating, the order stays in paid_pending_fulfillment with nothing to retry the confirmation.

- Resolve missing techniques at order time by fetching catalog product from Printful API and mapping slot→technique from its placements data
- Throw FulfillmentError if no valid placements after resolution (no silent blank orders)
- Default slot to 'default' when undefined on files
- Add shouldRetryConfirmation to Printful webhook for order_updated+draft when order is paid_pending_fulfillment
- Detect cost-calculation-pending errors in PingPay webhook with clear logging
- Add retry-confirmation cron job (POST /cron/retry-confirmations) as safety net for stuck orders
- Add findPendingConfirmation to OrderStore
- Improve logging throughout sync and order creation pipeline