### PR TITLE
order-cancel-issue-fixed

### DIFF
--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -481,7 +481,7 @@ export const contract = oc.router({
       path: "/admin/orders/delete",
       summary: "Delete orders (Admin)",
       description:
-        "Soft-deletes multiple orders. Drafts are hard-deleted. Other statuses are soft-deleted and logged.",
+        "Deletes orders. Unpaid/abandoned drafts cancel provider fulfillment first (idempotent if already gone). Paid/processing orders soft-delete without canceling fulfillment.",
       tags: ["Admin"],
     })
     .input(DeleteOrdersInputSchema)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -42,6 +42,7 @@ import { processManualWebhookEffect } from './services/webhooks/manual';
 import { logWebhookProcessingError, readWebhookBody } from './services/webhooks/common/route';
 import { runProviderTestStepEffect, saveProviderTestScenarioEffect } from './services/provider-tests';
 import { findOrderByFulfillmentRefEffect, processLuluWebhookEffect, processPrintfulWebhookEffect } from './services/fulfillment/webhook';
+import { isProviderOrderAlreadyGone } from './utils/provider-order-cancel';
 export * from './schema';
 
 
@@ -1234,6 +1235,14 @@ export default createPlugin({
       deleteOrders: builder.deleteOrders
         .use(requireAdmin)
         .handler(async ({ input, context }) => {
+          // Only unpaid/abandoned drafts should cancel provider fulfillment on delete.
+          // Paid/processing/shipped IDs are live production orders (see order-paid confirmOrder).
+          const providerCancellableOnDelete = new Set([
+            "draft_created",
+            "pending",
+            "payment_pending",
+            "expired",
+          ]);
           const actor = `admin:${context.nearAccountId || "unknown"}`;
           const errors: { orderId: string; error: string }[] = [];
           let deleted = 0;
@@ -1252,29 +1261,67 @@ export default createPlugin({
                 continue;
               }
 
-              if (order.draftOrderIds && Object.keys(order.draftOrderIds).length > 0) {
-                for (const [providerName, externalId] of Object.entries(order.draftOrderIds)) {
+              const shouldCancelProviderOrders = providerCancellableOnDelete.has(
+                order.status,
+              );
+
+              if (
+                shouldCancelProviderOrders &&
+                order.draftOrderIds &&
+                Object.keys(order.draftOrderIds).length > 0
+              ) {
+                let cancelFailed = false;
+
+                for (const [providerName, externalId] of Object.entries(
+                  order.draftOrderIds,
+                )) {
                   if (providerName === "manual") continue;
 
                   const provider = runtime.getProvider(providerName);
                   if (!provider) {
+                    const message = `Provider ${providerName} not found`;
                     console.warn(
-                      `[deleteOrders] Provider ${providerName} not found for order ${orderId}`,
+                      `[deleteOrders] ${message} for order ${orderId}`,
                     );
+                    errors.push({ orderId, error: message });
+                    cancelFailed = true;
                     continue;
                   }
 
                   try {
-                    await provider.client.cancelOrder({ id: externalId as string });
+                    await provider.client.cancelOrder({
+                      id: externalId as string,
+                    });
                     console.log(
                       `[deleteOrders] Cancelled ${providerName} order ${externalId} for order ${orderId}`,
                     );
                   } catch (err) {
+                    const message =
+                      err instanceof Error ? err.message : String(err);
+
+                    // Already gone at the provider = cleanup goal met (idempotent).
+                    if (isProviderOrderAlreadyGone(message)) {
+                      console.log(
+                        `[deleteOrders] ${providerName} order ${externalId} already gone for order ${orderId}; treating cancel as success`,
+                      );
+                      continue;
+                    }
+
                     console.warn(
                       `[deleteOrders] Failed to cancel ${providerName} order ${externalId}:`,
-                      err instanceof Error ? err.message : String(err),
+                      message,
                     );
+                    errors.push({
+                      orderId,
+                      error: `Failed to cancel ${providerName} order ${externalId}: ${message}`,
+                    });
+                    cancelFailed = true;
                   }
+                }
+
+                // Do not delete abandoned drafts if provider cancel did not succeed.
+                if (cancelFailed) {
+                  continue;
                 }
               }
 
@@ -1287,7 +1334,7 @@ export default createPlugin({
 
               if (deleteResult.deleted > 0) {
                 deleted++;
-            } else {
+              } else {
                 errors.push(...deleteResult.errors);
               }
             } catch (err) {

--- a/api/src/utils/provider-order-cancel.ts
+++ b/api/src/utils/provider-order-cancel.ts
@@ -1,0 +1,16 @@
+/**
+ * Provider cancel is idempotent when the external order is already gone.
+ * Treat these as successful cleanup so draft delete is not blocked forever.
+ */
+export function isProviderOrderAlreadyGone(errorMessage: string): boolean {
+  const msg = errorMessage.toLowerCase();
+  return (
+    msg.includes("not found") ||
+    msg.includes("404") ||
+    msg.includes("does not exist") ||
+    msg.includes("no such order") ||
+    msg.includes("already cancelled") ||
+    msg.includes("already canceled") ||
+    msg.includes("already deleted")
+  );
+}

--- a/api/tests/integration/delete-orders-cancel-guard.test.ts
+++ b/api/tests/integration/delete-orders-cancel-guard.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import * as schema from '@/db/schema';
+import { getPluginClient, getTestDb, runMigrations, teardown } from '../setup';
+import { clearOrders, createTestOrder } from '../helpers';
+
+const ADMIN_CONTEXT = {
+  nearAccountId: 'admin.near',
+  user: {
+    id: 'admin-user',
+    role: 'admin' as const,
+    email: 'admin@nearmerch.com',
+    name: 'Admin User',
+  },
+};
+
+describe('deleteOrders provider cancel guard', () => {
+  beforeAll(async () => {
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  beforeEach(async () => {
+    await clearOrders();
+  });
+
+  it('soft-deletes paid orders without requiring provider cancel', async () => {
+    const orderId = 'delete-guard-paid-001';
+    await createTestOrder(orderId, {
+      status: 'paid',
+      draftOrderIds: { printful: '999999991' },
+    });
+
+    const adminClient = await getPluginClient(ADMIN_CONTEXT);
+    const result = await adminClient.deleteOrders({ orderIds: [orderId] });
+
+    expect(result.deleted).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(schema.orders)
+      .where(eq(schema.orders.id, orderId))
+      .limit(1);
+
+    expect(row?.isDeleted).toBe(true);
+    expect(row?.status).toBe('paid');
+  });
+
+  it('soft-deletes processing orders without requiring provider cancel', async () => {
+    const orderId = 'delete-guard-processing-001';
+    await createTestOrder(orderId, {
+      status: 'processing',
+      draftOrderIds: { printful: '999999993' },
+    });
+
+    const adminClient = await getPluginClient(ADMIN_CONTEXT);
+    const result = await adminClient.deleteOrders({ orderIds: [orderId] });
+
+    expect(result.deleted).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(schema.orders)
+      .where(eq(schema.orders.id, orderId))
+      .limit(1);
+
+    expect(row?.isDeleted).toBe(true);
+    expect(row?.status).toBe('processing');
+  });
+
+  it('does not delete abandoned drafts when provider is unavailable', async () => {
+    const orderId = 'delete-guard-draft-001';
+    await createTestOrder(orderId, {
+      status: 'draft_created',
+      draftOrderIds: { printful: '999999992' },
+    });
+
+    const adminClient = await getPluginClient(ADMIN_CONTEXT);
+    const result = await adminClient.deleteOrders({ orderIds: [orderId] });
+
+    expect(result.deleted).toBe(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(schema.orders)
+      .where(eq(schema.orders.id, orderId))
+      .limit(1);
+
+    expect(row?.isDeleted).toBe(false);
+    expect(row?.status).toBe('draft_created');
+  });
+});

--- a/api/tests/unit/provider-order-cancel.test.ts
+++ b/api/tests/unit/provider-order-cancel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isProviderOrderAlreadyGone } from "@/utils/provider-order-cancel";
+
+describe("isProviderOrderAlreadyGone", () => {
+  it("treats missing provider orders as already cleaned up", () => {
+    expect(
+      isProviderOrderAlreadyGone(
+        "Failed to cancel Printful order: Not found",
+      ),
+    ).toBe(true);
+    expect(isProviderOrderAlreadyGone("404 Order does not exist")).toBe(true);
+    expect(isProviderOrderAlreadyGone("Order already cancelled")).toBe(true);
+    expect(isProviderOrderAlreadyGone("already deleted")).toBe(true);
+  });
+
+  it("does not treat real cancel failures as already gone", () => {
+    expect(isProviderOrderAlreadyGone("Unauthorized")).toBe(false);
+    expect(isProviderOrderAlreadyGone("Rate limit exceeded")).toBe(false);
+    expect(
+      isProviderOrderAlreadyGone("Failed to cancel Printful order: timeout"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary
Fixes 175: admin `deleteOrders` no longer cancels Printful/Lulu fulfillment without checking status.

- Cancel provider drafts only for unpaid/abandoned statuses
- Paid/processing/shipped → soft-delete only (no `cancelOrder`)
- If draft cancel fails, do not delete the order
- Treat provider “not found / already gone” as successful cleanup

video for better understanding:
https://drive.google.com/file/d/1EX433kVNf0AHMZUOXRdsDXbPhhaorLCV/view?usp=sharing

added some demo order in printful and then tested them one by one.