### PR TITLE
fixed order ownership for checkout sessions

### DIFF
--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -410,7 +410,8 @@ export const contract = oc.router({
       tags: ["Orders"],
     })
     .input(z.object({ sessionId: z.string() }))
-    .output(z.object({ order: OrderWithItemsSchema.nullable() })),
+    .output(z.object({ order: OrderWithItemsSchema.nullable() }))
+    .errors({ FORBIDDEN, UNAUTHORIZED }),
 
   subscribeOrderStatus: oc
     .route({

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -996,7 +996,7 @@ export default createPlugin({
       getOrderByCheckoutSession: builder.getOrderByCheckoutSession
         .use(requireAuth)
         .handler(
-        async ({ input }) => {
+        async ({ input, context, errors }) => {
           const exit = await managedRuntime.runPromiseExit(
             Effect.gen(function* () {
               const store = yield* OrderStore;
@@ -1014,7 +1014,16 @@ export default createPlugin({
             });
           }
 
-          return { order: exit.value };
+          const order = exit.value;
+
+          if (order && order.userId !== context.nearAccountId) {
+            throw errors.FORBIDDEN({
+              message: "You do not have permission to access this order",
+              data: { action: "read" },
+            });
+          }
+
+          return { order };
         },
       ),
 

--- a/api/tests/integration/checkout-flow.test.ts
+++ b/api/tests/integration/checkout-flow.test.ts
@@ -206,7 +206,7 @@ describe('Checkout Flow E2E', () => {
       expect(order.order.status).toBe('payment_failed');
     });
 
-    it('should find order by checkout session ID', async () => {
+    it('should only find an order by checkout session ID for its owner', async () => {
       const client = await getPluginClient({ nearAccountId: TEST_USER });
 
       const quoteResult = await client.quote({
@@ -236,6 +236,14 @@ describe('Checkout Flow E2E', () => {
       expect(result.order).toBeDefined();
       expect(result.order?.id).toBe(checkoutResult.orderId);
       expect(result.order?.checkoutSessionId).toBe(sessionId);
+
+      const otherUserClient = await getPluginClient({
+        nearAccountId: 'other-user.near',
+      });
+
+      await expect(
+        otherUserClient.getOrderByCheckoutSession({ sessionId }),
+      ).rejects.toThrow('You do not have permission to access this order');
     });
 
     it('should process webhook using sessionId fallback when orderId not in metadata', async () => {


### PR DESCRIPTION
## Summary

  Fixes #187 by enforcing ownership checks when retrieving an order using its checkout session ID.

  ## Changes

  - Verifies that the order’s `userId` matches the authenticated `nearAccountId`.
  - Returns `403 Forbidden` when another authenticated user attempts to access the order.
  - Adds integration coverage for owner and non-owner access.

  ## Testing

  - Confirmed the owner receives `200` and can view the order.
  - Confirmed a different authenticated user receives `403` with no order information exposed.
  - Full test suite and typecheck pass.

video for ref:
https://github.com/user-attachments/assets/f8db8aa6-f7cf-4f23-883a-1486b1588c23

chrome is for userA and brave is for userB.