### PR TITLE
Fixed #189 by securing POST /api/webhooks/manual

### DIFF
--- a/.changeset/secure-manual-webhooks.md
+++ b/.changeset/secure-manual-webhooks.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Require admin authentication or a valid HMAC signature for manual order-status webhooks.

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ LULU_CLIENT_SECRET=
 PING_API_KEY=
 PING_WEBHOOK_SECRET=
 
+# HMAC secret for POST /api/webhooks/manual
+MANUAL_WEBHOOK_SECRET=
+
 # Resend (https://resend.com/) — email delivery for manual fulfillment notifications
 RESEND_API_KEY=
 MANUAL_FULFILLMENT_FROM_EMAIL=orders@nearmerch.com

--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -535,7 +535,8 @@ export const contract = oc.router({
       tags: ['Webhooks'],
     })
     .input(z.unknown())
-    .output(WebhookResponseSchema),
+    .output(WebhookResponseSchema)
+    .errors({ UNAUTHORIZED }),
 
   pingWebhook: oc
     .route({

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -39,6 +39,7 @@ import { verifyPingPayWebhookSignature } from './services/payment/pingpay/servic
 import { handlePingPayWebhookEffect } from './services/payment/pingpay/webhook';
 import { processPaymentSuccessEffect } from './services/payment/payment-success';
 import { processManualWebhookEffect } from './services/webhooks/manual';
+import { verifyManualWebhookSignature } from './services/webhooks/manual-auth';
 import { logWebhookProcessingError, readWebhookBody } from './services/webhooks/common/route';
 import { runProviderTestStepEffect, saveProviderTestScenarioEffect } from './services/provider-tests';
 import { findOrderByFulfillmentRefEffect, processLuluWebhookEffect, processPrintfulWebhookEffect } from './services/fulfillment/webhook';
@@ -72,6 +73,7 @@ export default createPlugin({
     LULU_CLIENT_SECRET: z.string().optional(),
     PING_API_KEY: z.string().optional(),
     PING_WEBHOOK_SECRET: z.string().optional(),
+    MANUAL_WEBHOOK_SECRET: z.string().optional(),
     ACCESS_KEY_ID: z.string().optional(),
     SECRET_ACCESS_KEY: z.string().optional(),
     MANUAL_FULFILLMENT_FROM_EMAIL: z.string().optional(),
@@ -1579,7 +1581,31 @@ export default createPlugin({
         return { received: true };
       }),
 
-      manualWebhook: builder.manualWebhook.handler(async ({ input }) => {
+      manualWebhook: builder.manualWebhook.handler(async ({ input, context }) => {
+        const isAdmin = Boolean(
+          context.nearAccountId && context.user?.role === 'admin',
+        );
+
+        if (!isAdmin) {
+          const signature = context.reqHeaders?.get('x-manual-signature') ?? '';
+          const body = await readWebhookBody({
+            input,
+            getRawBody: context.getRawBody,
+          });
+
+          if (
+            !verifyManualWebhookSignature(
+              body,
+              signature,
+              secrets.MANUAL_WEBHOOK_SECRET,
+            )
+          ) {
+            throw new ORPCError('UNAUTHORIZED', {
+              message: 'Invalid or missing manual webhook authorization',
+            });
+          }
+        }
+
         const parsed = ManualWebhookPayloadSchema.parse(input);
 
         const order = await managedRuntime.runPromise(

--- a/api/src/services/webhooks/manual-auth.ts
+++ b/api/src/services/webhooks/manual-auth.ts
@@ -1,0 +1,30 @@
+import * as crypto from 'crypto';
+
+const SIGNATURE_PREFIX = 'sha256=';
+
+export function verifyManualWebhookSignature(
+  payload: string,
+  signature: string,
+  webhookSecret?: string,
+): boolean {
+  if (!webhookSecret || !signature.startsWith(SIGNATURE_PREFIX)) {
+    return false;
+  }
+
+  const suppliedDigest = signature.slice(SIGNATURE_PREFIX.length);
+  if (!/^[a-f0-9]{64}$/i.test(suppliedDigest)) {
+    return false;
+  }
+
+  const expectedDigest = crypto
+    .createHmac('sha256', webhookSecret)
+    .update(payload)
+    .digest('hex');
+  const supplied = Buffer.from(suppliedDigest, 'hex');
+  const expected = Buffer.from(expectedDigest, 'hex');
+
+  return (
+    supplied.length === expected.length &&
+    crypto.timingSafeEqual(supplied, expected)
+  );
+}

--- a/api/tests/integration/manual-webhook-auth.test.ts
+++ b/api/tests/integration/manual-webhook-auth.test.ts
@@ -1,0 +1,132 @@
+import * as schema from '@/db/schema';
+import { createHmac } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { clearOrders, createTestOrder } from '../helpers';
+import { getPluginClient, getTestDb, runMigrations, teardown } from '../setup';
+
+const TEST_MANUAL_WEBHOOK_SECRET = 'manual_whsec_test_secret';
+
+const findOrder = (orderId: string) =>
+  getTestDb().query.orders.findFirst({
+    where: eq(schema.orders.id, orderId),
+  });
+
+const signBody = (body: string) =>
+  `sha256=${createHmac('sha256', TEST_MANUAL_WEBHOOK_SECRET)
+    .update(body)
+    .digest('hex')}`;
+
+describe('Manual webhook authorization', () => {
+  beforeAll(async () => {
+    await runMigrations();
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  beforeEach(async () => {
+    await clearOrders();
+  });
+
+  it('rejects an anonymous unsigned status update and leaves the order unchanged', async () => {
+    const orderId = 'manual-auth-anonymous';
+    const payload = { orderId, status: 'delivered' as const };
+    await createTestOrder(orderId);
+    const client = await getPluginClient();
+
+    await expect(client.manualWebhook(payload)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect((await findOrder(orderId))?.status).toBe('pending');
+  });
+
+  it('rejects an authenticated customer without a signature', async () => {
+    const orderId = 'manual-auth-customer';
+    const payload = { orderId, status: 'cancelled' as const };
+    await createTestOrder(orderId, { userId: 'security-victim.near' });
+    const client = await getPluginClient({
+      nearAccountId: 'security-victim.near',
+      user: { id: 'security-victim-user', role: 'user' },
+    });
+
+    await expect(client.manualWebhook(payload)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect((await findOrder(orderId))?.status).toBe('pending');
+  });
+
+  it('rejects an invalid signature and leaves the order unchanged', async () => {
+    const orderId = 'manual-auth-invalid-signature';
+    const payload = { orderId, status: 'refunded' as const };
+    const rawBody = JSON.stringify(payload);
+    await createTestOrder(orderId);
+    const headers = new Headers({
+      'x-manual-signature': `sha256=${'0'.repeat(64)}`,
+    });
+    const client = await getPluginClient({
+      reqHeaders: headers,
+      getRawBody: async () => rawBody,
+    });
+
+    await expect(client.manualWebhook(payload)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect((await findOrder(orderId))?.status).toBe('pending');
+  });
+
+  it('rejects a valid signature when the request body was changed', async () => {
+    const orderId = 'manual-auth-tampered-body';
+    const originalBody = JSON.stringify({ orderId, status: 'delivered' });
+    const payload = { orderId, status: 'refunded' as const };
+    const tamperedBody = JSON.stringify(payload);
+    await createTestOrder(orderId);
+    const headers = new Headers({
+      'x-manual-signature': signBody(originalBody),
+    });
+    const client = await getPluginClient({
+      reqHeaders: headers,
+      getRawBody: async () => tamperedBody,
+    });
+
+    await expect(client.manualWebhook(payload)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect((await findOrder(orderId))?.status).toBe('pending');
+  });
+
+  it('accepts a correctly signed webhook and updates the order', async () => {
+    const orderId = 'manual-auth-valid-signature';
+    const payload = { orderId, status: 'delivered' as const };
+    const rawBody = JSON.stringify(payload);
+    await createTestOrder(orderId);
+    const headers = new Headers({
+      'x-manual-signature': signBody(rawBody),
+    });
+    const client = await getPluginClient({
+      reqHeaders: headers,
+      getRawBody: async () => rawBody,
+    });
+
+    await expect(client.manualWebhook(payload)).resolves.toEqual({
+      received: true,
+    });
+    expect((await findOrder(orderId))?.status).toBe('delivered');
+  });
+
+  it('accepts an authenticated admin without a signature', async () => {
+    const orderId = 'manual-auth-admin';
+    const payload = { orderId, status: 'refunded' as const };
+    await createTestOrder(orderId);
+    const client = await getPluginClient({
+      nearAccountId: 'ballzz.near',
+      user: { id: 'ballzz-admin-user', role: 'admin' },
+    });
+
+    await expect(client.manualWebhook(payload)).resolves.toEqual({
+      received: true,
+    });
+    expect((await findOrder(orderId))?.status).toBe('refunded');
+  });
+});

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -56,6 +56,7 @@ const TEST_CONFIG = {
     API_DATABASE_URL: TEST_DB_URL,
     PING_API_KEY: 'test_api_key',
     PING_WEBHOOK_SECRET: 'whsec_test_secret_key',
+    MANUAL_WEBHOOK_SECRET: 'manual_whsec_test_secret',
     // Printful v2 webhook secret is hex; tests compute HMAC over raw body.
     PRINTFUL_WEBHOOK_SECRET: 'a'.repeat(64),
   },

--- a/bos.config.json
+++ b/bos.config.json
@@ -87,6 +87,7 @@
         "PRINTFUL_WEBHOOK_SECRET",
         "PING_API_KEY",
         "PING_WEBHOOK_SECRET",
+        "MANUAL_WEBHOOK_SECRET",
         "LULU_CLIENT_KEY",
         "LULU_CLIENT_SECRET",
         "ACCESS_KEY_ID",


### PR DESCRIPTION
## Summary

  Fixes #189 by securing POST /api/webhooks/manual, which previously allowed anyone with an orderId to change an order’s
  status without authentication.

  ## Changes

  - Rejects unauthenticated and unsigned requests with 401 Unauthorized.
  - Allows status updates only when:
      - The request has a valid HMAC-SHA256 webhook signature, or
      - The requester is an authenticated admin.

  - Uses timing-safe signature comparison.
  - Fails securely when MANUAL_WEBHOOK_SECRET is not configured.
  - Adds MANUAL_WEBHOOK_SECRET to the environment configuration.
  - Adds regression tests for:
      - Anonymous requests
      - Authenticated customer requests
      - Invalid or tampered signatures
      - Valid signed requests
      - Authenticated admin requests


  ## Demo

  A video is attached showing that customer/unsigned requests are rejected while authorized admin access continues to
  work.
https://drive.google.com/file/d/1ZRbPsKa7WGe7df7GYsQZnq5QUWBqfxmA/view?usp=sharing