### PR TITLE
issue related to update inventory is fixed

### DIFF
--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/$productId.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/$productId.tsx
@@ -1,8 +1,9 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useBlocker, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ExternalLink, ImagePlus, Loader2, Lock, Star, Trash2, Unlock, Upload, GripVertical, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { DragDropProvider, DragOverlay, useDraggable, useDroppable } from "@dnd-kit/react";
+import { AlertDialog } from "radix-ui";
 import { useProduct } from "@/integrations/api";
 import { useUpdateProduct, useRequestAssetUpload, useConfirmAssetUpload } from "@/integrations/api/admin";
 import { productKeys } from "@/integrations/api/keys";
@@ -54,6 +55,46 @@ interface VariantPriceDraft {
   sku?: string;
   attributes: Array<{ name: string; value: string }>;
   price: string;
+}
+
+function UnsavedChangesDialog({
+  open,
+  onKeepEditing,
+  onDiscard,
+}: {
+  open: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <AlertDialog.Root open={open}>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className="fixed inset-0 z-[80] bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
+        <AlertDialog.Content className="bg-background fixed top-1/2 left-1/2 z-[90] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-2xl duration-300 sm:max-w-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95">
+          <div className="flex flex-col gap-2 text-center sm:text-left">
+            <AlertDialog.Title className="text-lg leading-none font-semibold">
+              Discard unsaved changes?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="text-muted-foreground text-sm">
+              Your product changes have not been saved. Discarding them cannot be undone.
+            </AlertDialog.Description>
+          </div>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <AlertDialog.Cancel asChild>
+              <Button type="button" variant="outline" onClick={onKeepEditing}>
+                Keep editing
+              </Button>
+            </AlertDialog.Cancel>
+            <AlertDialog.Action asChild>
+              <Button type="button" variant="destructive" onClick={onDiscard}>
+                Discard changes
+              </Button>
+            </AlertDialog.Action>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
 }
 
 function formatVariantAttributes(attributes: Array<{ name: string; value: string }>) {
@@ -233,13 +274,21 @@ function ProductEditSheet() {
       })
     : "";
   const hasUnsavedChanges = currentHash !== lastSavedHash && initialized;
+  const shouldBlockNavigation = useCallback(
+    () => hasUnsavedChanges,
+    [hasUnsavedChanges],
+  );
+  const blocker = useBlocker({
+    shouldBlockFn: shouldBlockNavigation,
+    withResolver: true,
+    enableBeforeUnload: false,
+  });
 
   useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (hasUnsavedChanges) {
-        e.preventDefault();
-      }
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) event.preventDefault();
     };
+
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [hasUnsavedChanges]);
@@ -440,8 +489,9 @@ function ProductEditSheet() {
   }, [updateMutation, productId, name, description, price, priceLocked, variantPrices, images, thumbnailImage, product, queryClient, hasMultipleVariants]);
 
   return (
-    <Sheet open onOpenChange={(open) => { if (!open) handleClose(); }}>
-      <SheetContent side="right" hideCloseButton>
+    <>
+      <Sheet open onOpenChange={(open) => { if (!open) handleClose(); }}>
+        <SheetContent side="right" hideCloseButton>
         {isLoading ? (
           <div className="flex items-center justify-center flex-1">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#00EC97]" />
@@ -711,7 +761,17 @@ function ProductEditSheet() {
             </div>
           </>
         ) : null}
-      </SheetContent>
-    </Sheet>
+        </SheetContent>
+      </Sheet>
+      <UnsavedChangesDialog
+        open={blocker.status === "blocked"}
+        onKeepEditing={() => {
+          if (blocker.status === "blocked") blocker.reset();
+        }}
+        onDiscard={() => {
+          if (blocker.status === "blocked") blocker.proceed();
+        }}
+      />
+    </>
   );
 }

--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/-$productId.test.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/inventory/-$productId.test.tsx
@@ -1,0 +1,206 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const routerMock = vi.hoisted(() => {
+  let attemptNavigation: (() => void) | undefined;
+
+  return {
+    navigate: vi.fn(() => attemptNavigation?.()),
+    proceed: vi.fn(),
+    reset: vi.fn(),
+    setAttemptNavigation: (attempt: (() => void) | undefined) => {
+      attemptNavigation = attempt;
+    },
+  };
+});
+
+vi.mock("@tanstack/react-router", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  const idleResolver = {
+    status: "idle" as const,
+    current: undefined,
+    next: undefined,
+    action: undefined,
+    proceed: undefined,
+    reset: undefined,
+  };
+  type TestResolver =
+    | typeof idleResolver
+    | {
+        status: "blocked";
+        current: never;
+        next: never;
+        action: never;
+        proceed: () => void;
+        reset: () => void;
+      };
+
+  return {
+    createFileRoute:
+      () =>
+      (options: { component: () => React.ReactNode }) => ({
+        options,
+        useParams: () => ({ productId: "product-1" }),
+      }),
+    useNavigate: () => routerMock.navigate,
+    useBlocker: ({
+      shouldBlockFn,
+    }: {
+      shouldBlockFn: () => boolean | Promise<boolean>;
+    }) => {
+      const [resolver, setResolver] = React.useState<TestResolver>(idleResolver);
+
+      routerMock.setAttemptNavigation(async () => {
+        if (!(await shouldBlockFn())) return;
+
+        setResolver({
+          status: "blocked",
+          current: {} as never,
+          next: {} as never,
+          action: "PUSH" as never,
+          proceed: () => {
+            routerMock.proceed();
+            setResolver(idleResolver);
+          },
+          reset: () => {
+            routerMock.reset();
+            setResolver(idleResolver);
+          },
+        });
+      });
+
+      return resolver;
+    },
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@dnd-kit/react", () => ({
+  DragDropProvider: ({ children }: { children: React.ReactNode }) => children,
+  DragOverlay: () => null,
+  useDraggable: () => ({ ref: vi.fn() }),
+  useDroppable: () => ({ ref: vi.fn() }),
+}));
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onOpenChange?.(false)}>
+        Close sheet overlay
+      </button>
+      {children}
+    </div>
+  ),
+  SheetContent: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/integrations/api", () => ({
+  useProduct: () => ({
+    data: {
+      product: {
+        id: "product-1",
+        slug: "test-product",
+        title: "Test Product",
+        description: "Original description",
+        price: 20,
+        priceLocked: false,
+        images: [],
+        variants: [],
+      },
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/integrations/api/admin", () => ({
+  useUpdateProduct: () => ({ mutate: vi.fn(), isPending: false }),
+  useRequestAssetUpload: () => ({ mutateAsync: vi.fn() }),
+  useConfirmAssetUpload: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { Route } from "./$productId";
+
+const ProductEditSheet = Route.options.component as ComponentType;
+
+describe("ProductEditSheet unsaved-change guard", () => {
+  beforeEach(() => {
+    routerMock.navigate.mockClear();
+    routerMock.proceed.mockClear();
+    routerMock.reset.mockClear();
+    routerMock.setAttemptNavigation(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("requests the native browser warning when unsaved changes would be unloaded", async () => {
+    render(<ProductEditSheet />);
+
+    const nameInput = await screen.findByLabelText("Name");
+    fireEvent.change(nameInput, { target: { value: "Changed Product" } });
+
+    const beforeUnloadEvent = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(beforeUnloadEvent);
+
+    expect(beforeUnloadEvent.defaultPrevented).toBe(true);
+  });
+
+  it("keeps editing when a close attempt is cancelled", async () => {
+    render(<ProductEditSheet />);
+
+    const nameInput = await screen.findByLabelText("Name");
+    fireEvent.change(nameInput, { target: { value: "Changed Product" } });
+    fireEvent.click(screen.getByRole("button", { name: "Close edit panel" }));
+
+    expect(
+      await screen.findByRole("alertdialog", {
+        name: "Discard unsaved changes?",
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("alertdialog", {
+          name: "Discard unsaved changes?",
+        }),
+      ).toBeNull();
+    });
+    expect((nameInput as HTMLInputElement).value).toBe("Changed Product");
+    expect(routerMock.reset).toHaveBeenCalledOnce();
+    expect(routerMock.proceed).not.toHaveBeenCalled();
+  });
+
+  it("continues the blocked navigation when changes are discarded", async () => {
+    render(<ProductEditSheet />);
+
+    const description = await screen.findByLabelText("Description");
+    fireEvent.change(description, { target: { value: "Changed description" } });
+    fireEvent.click(screen.getByRole("button", { name: "Close sheet overlay" }));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Discard changes" }),
+    );
+
+    expect(routerMock.proceed).toHaveBeenCalledOnce();
+    expect(routerMock.reset).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds protection against losing unsaved product edits in the inventory editor.
- Shows a custom confirmation dialog for closing or navigating away.
- Keeps the native browser warning for refresh and tab close.
- Provides “Keep editing” and “Discard changes” options.


https://github.com/user-attachments/assets/7c087e10-8199-4140-bcee-674facecb91b

